### PR TITLE
Fix imports and logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ lxml
 pytesseract
 opensearch-py
 pymongo
+pyyaml
 aiofiles>=23.1.0  # For async file operations
 diskcache>=5.6.1  # For disk-based caching

--- a/web3_data_center/clients/opensearch_client.py
+++ b/web3_data_center/clients/opensearch_client.py
@@ -5,10 +5,15 @@ from urllib.parse import urlparse
 import traceback
 import time
 
-from opensearchpy import AsyncOpenSearch, OpenSearch,ConnectionTimeout, OpenSearchException, NotFoundError
+from opensearchpy import (
+    AsyncOpenSearch,
+    ConnectionTimeout,
+    OpenSearchException,
+    NotFoundError,
+    RequestError,
+    TransportError,
+)
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
-
-from opensearchpy import OpenSearch, RequestError, TransportError
 
 from .base_client import BaseClient
 
@@ -488,13 +493,14 @@ class OpenSearchClient(BaseClient):
             response = await self.client.get(index="eth_block", id=tx_hash)
             return response['_source']['EthChangeIn']
         except RequestError as e:
-            logger.error(f"OpenSearch request error: {e}")
-            logger.error(f"Query: {query}")
-            logger.error(f"Error details: {e.info}")
+            logger.error(
+                f"OpenSearch request error while fetching EthChangeIn for {tx_hash}: {e}"
+            )
             raise
         except TransportError as e:
-            logger.error(f"OpenSearch transport error: {e}")
-            logger.error(f"Query: {query}")
+            logger.error(
+                f"OpenSearch transport error while fetching EthChangeIn for {tx_hash}: {e}"
+            )
             raise
 
     @staticmethod


### PR DESCRIPTION
## Summary
- add missing `pyyaml` dependency
- clean up OpenSearch imports
- improve error logging for `get_eth_change_in`

## Testing
- `python -m py_compile web3_data_center/clients/opensearch_client.py`
- `python -m py_compile web3_data_center/clients/base_client.py`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'yaml')*